### PR TITLE
Updates for Kotlin 1.9.10 and Java 17, newer gradle and lint warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 plugins {
-    kotlin("multiplatform") version "1.8.10"
+    kotlin("multiplatform") version "1.9.10"
     id("com.vanniktech.maven.publish") version "0.25.1"
 }
 
@@ -15,8 +15,9 @@ repositories {
 kotlin {
     jvm {
         compilations.all {
-            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.jvmTarget = "17"
         }
+
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
         }
@@ -27,7 +28,10 @@ kotlin {
     linuxArm64()
     mingwX64()
 
-    
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+
     sourceSets {
         val commonMain by getting
         val commonTest by getting {
@@ -35,24 +39,32 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
+
+        // Mac OS
         val macosMain by creating {
             dependsOn(commonMain)
         }
         val macosTest by creating {
             dependsOn(commonTest)
         }
+
+        // Unix
         val unixMain by creating {
             dependsOn(commonMain)
         }
         val unixTest by creating {
             dependsOn(commonTest)
         }
+
+        // Windows
         val windowsMain by creating {
             dependsOn(commonMain)
         }
         val windowsTest by creating {
             dependsOn(commonTest)
         }
+
+        // JVM
         val jvmMain by getting {
             dependsOn(macosMain)
             dependsOn(unixMain)
@@ -67,6 +79,7 @@ kotlin {
             dependsOn(windowsTest)
         }
 
+        // Native
         val nativeMain by creating {
             dependsOn(commonMain)
         }
@@ -74,6 +87,7 @@ kotlin {
             dependsOn(commonTest)
         }
 
+        // Mac OS Native
         val macosNativeMain by creating {
             dependsOn(nativeMain)
             dependsOn(macosMain)
@@ -95,6 +109,7 @@ kotlin {
             dependsOn(macosNativeTest)
         }
 
+        // Linux
         val linuxNativeMain by creating {
             dependsOn(nativeMain)
             dependsOn(unixMain)
@@ -116,6 +131,7 @@ kotlin {
             dependsOn(linuxNativeTest)
         }
 
+        // Mingw
         val mingwNativeMain by creating {
             dependsOn(nativeMain)
             dependsOn(windowsMain)
@@ -134,7 +150,7 @@ kotlin {
 }
 
 // Read in the signing.properties file if it is exists
-val signingPropsFile = rootProject.file("release/signing.properties")
+val signingPropsFile: File = rootProject.file("release/signing.properties")
 if (signingPropsFile.exists()) {
     Properties().apply {
         signingPropsFile.inputStream().use {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 kotlin {
     jvm {
         compilations.all {
-            kotlinOptions.jvmTarget = "17"
+            kotlinOptions.jvmTarget = "1.8"
         }
 
         testRuns["test"].executionTask.configure {
@@ -27,10 +27,6 @@ kotlin {
     linuxX64()
     linuxArm64()
     mingwX64()
-
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
 
     sourceSets {
         val commonMain by getting

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,5 @@ POM_DEVELOPER_URL=https://github.com/Syer10/
 
 SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
+
+kotlin.native.cacheKind.macosArm64=none

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
-rootProject.name = "Kotlin-Multiplatform-Appdirs"
+rootProject.name = "Kotlin-Multiplatform-AppDirs"
 

--- a/src/jvmTest/kotlin/ca/gosyer/appdirs/LinuxJvmTest.kt
+++ b/src/jvmTest/kotlin/ca/gosyer/appdirs/LinuxJvmTest.kt
@@ -1,6 +1,5 @@
 package ca.gosyer.appdirs
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 

--- a/src/jvmTest/kotlin/ca/gosyer/appdirs/MacosJvmTest.kt
+++ b/src/jvmTest/kotlin/ca/gosyer/appdirs/MacosJvmTest.kt
@@ -1,6 +1,5 @@
 package ca.gosyer.appdirs
 
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 

--- a/src/linuxNativeMain/kotlin/ca/gosyer/appdirs/impl/LinuxEnvResolver.kt
+++ b/src/linuxNativeMain/kotlin/ca/gosyer/appdirs/impl/LinuxEnvResolver.kt
@@ -1,8 +1,10 @@
 package ca.gosyer.appdirs.impl
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import platform.posix.getenv
 
+@OptIn(ExperimentalForeignApi::class)
 class LinuxEnvResolver : UnixEnvResolver {
     override fun get(name: String): String? = getenv(name)?.toKString()
 }

--- a/src/linuxNativeMain/kotlin/ca/gosyer/appdirs/impl/LinuxUtil.kt
+++ b/src/linuxNativeMain/kotlin/ca/gosyer/appdirs/impl/LinuxUtil.kt
@@ -1,5 +1,6 @@
 package ca.gosyer.appdirs.impl
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.toKString
@@ -7,6 +8,7 @@ import platform.posix.getenv
 import platform.posix.getpwuid
 import platform.posix.getuid
 
+@OptIn(ExperimentalForeignApi::class)
 internal actual fun home(): String {
     memScoped {
         val home = getenv("HOME")

--- a/src/macosNativeMain/kotlin/ca/gosyer/appdirs/impl/MacosUtil.kt
+++ b/src/macosNativeMain/kotlin/ca/gosyer/appdirs/impl/MacosUtil.kt
@@ -1,5 +1,6 @@
 package ca.gosyer.appdirs.impl
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.toKString
@@ -7,6 +8,7 @@ import platform.posix.getenv
 import platform.posix.getpwuid
 import platform.posix.getuid
 
+@OptIn(ExperimentalForeignApi::class)
 internal actual fun home(): String {
     memScoped {
         val home = getenv("HOME")

--- a/src/macosTest/kotlin/ca/gosyer/appdirs/MacosTest.kt
+++ b/src/macosTest/kotlin/ca/gosyer/appdirs/MacosTest.kt
@@ -1,6 +1,5 @@
 package ca.gosyer.appdirs
 
-import ca.gosyer.appdirs.impl.MacOSXAppDirs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -8,7 +7,7 @@ abstract class MacosTest : AppDirsTest() {
     @Test
     fun testRealPathMacUserDataDir() {
         assertEquals(
-            home + "/Library/Application Support",
+            "$home/Library/Application Support",
             AppDirs(null).getUserDataDir()
         )
     }
@@ -16,7 +15,7 @@ abstract class MacosTest : AppDirsTest() {
     @Test
     fun testRealPathMacUserConfigDir() {
         assertEquals(
-            home + "/Library/Preferences",
+            "$home/Library/Preferences",
             AppDirs(null).getUserConfigDir()
         )
     }
@@ -24,7 +23,7 @@ abstract class MacosTest : AppDirsTest() {
     @Test
     fun testRealPathMacUserCacheDir() {
         assertEquals(
-            home + "/Library/Caches",
+            "$home/Library/Caches",
             AppDirs(null).getUserCacheDir()
         )
     }
@@ -32,7 +31,7 @@ abstract class MacosTest : AppDirsTest() {
     @Test
     fun testRealPathMacUserLogDir() {
         assertEquals(
-            home + "/Library/Logs",
+            "$home/Library/Logs",
             AppDirs(null).getUserLogDir()
         )
     }

--- a/src/mingwNativeMain/kotlin/ca/gosyer/appdirs/impl/ShellFolderResolver.kt
+++ b/src/mingwNativeMain/kotlin/ca/gosyer/appdirs/impl/ShellFolderResolver.kt
@@ -2,12 +2,7 @@ package ca.gosyer.appdirs.impl
 
 import ca.gosyer.appdirs.AppDirsException
 import ca.gosyer.appdirs.impl.WindowsAppDirs.FolderId
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.cValue
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.ptr
-import kotlinx.cinterop.toKStringFromUtf16
-import kotlinx.cinterop.value
+import kotlinx.cinterop.*
 import platform.posix.GUID
 import platform.windows.CSIDL_APPDATA
 import platform.windows.CSIDL_COMMON_APPDATA
@@ -15,18 +10,18 @@ import platform.windows.CSIDL_LOCAL_APPDATA
 import platform.windows.FOLDERID_LocalAppData
 import platform.windows.FOLDERID_ProgramData
 import platform.windows.FOLDERID_RoamingAppData
-import platform.windows.KNOWNFOLDERID
 import platform.windows.LPWSTRVar
 import platform.windows.PWSTRVar
 import platform.windows.SHGetFolderPathW
 import platform.windows.SHGetKnownFolderPath
 
+@OptIn(ExperimentalForeignApi::class)
 internal class ShellFolderResolver : WindowsFolderResolver {
     override operator fun get(folderId: FolderId): String {
         return try {
             memScoped {
                 val result = alloc<PWSTRVar>()
-                val hResult = SHGetKnownFolderPath(convertFolderIdToGuid(folderId).ptr, 0, null, result.ptr)
+                val hResult = SHGetKnownFolderPath(convertFolderIdToGuid(folderId).ptr, 0u, null, result.ptr)
                 if (hResult < 0) {
                     throw AppDirsException(
                         "SHGetKnownFolderPath returns an error: $hResult"
@@ -40,7 +35,7 @@ internal class ShellFolderResolver : WindowsFolderResolver {
             try {
                 memScoped {
                     val result = alloc<LPWSTRVar>()
-                    val hResult = SHGetFolderPathW(null, convertFolderIdToCsidl(folderId), null, 0, result.value)
+                    val hResult = SHGetFolderPathW(null, convertFolderIdToCsidl(folderId), null, 0u, result.value)
                     if (hResult < 0) {
                         throw AppDirsException(
                             "SHGetKnownFolderPath returns an error: $hResult"

--- a/src/mingwNativeMain/kotlin/ca/gosyer/appdirs/impl/WindowsUtil.kt
+++ b/src/mingwNativeMain/kotlin/ca/gosyer/appdirs/impl/WindowsUtil.kt
@@ -1,9 +1,11 @@
 package ca.gosyer.appdirs.impl
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.toKString
 import platform.posix.getenv
 
+@OptIn(ExperimentalForeignApi::class)
 internal actual fun home(): String {
     memScoped {
         return getenv("USERPROFILE")!!.toKString()

--- a/src/unixTest/kotlin/ca/gosyer/appdirs/UnixTest.kt
+++ b/src/unixTest/kotlin/ca/gosyer/appdirs/UnixTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 abstract class UnixTest : AppDirsTest() {
-    fun AppDirs(
+    private fun AppDirs(
         appName: String?,
         appAuthor: String?,
         vararg extra: String,

--- a/src/windowsTest/kotlin/ca/gosyer/appdirs/WindowsTest.kt
+++ b/src/windowsTest/kotlin/ca/gosyer/appdirs/WindowsTest.kt
@@ -1,7 +1,5 @@
 package ca.gosyer.appdirs
 
-import ca.gosyer.appdirs.impl.WindowsAppDirs
-import ca.gosyer.appdirs.impl.WindowsFolderResolver
 import kotlin.test.Test
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
A few updates that I made (locally) for my own use that I thought you might find useful -
* Kotlin 1.9.10
    * meant adding `@OptIn(ExperimentalForeignApi::class)` to a few places
* Java 17
* Gradle 8.3
* Cleaned up a few lint warnings for unused imports and the like

Note: the root project name change fixes an error importing "java.lang.IllegalStateException: Module entity with name: Kotlin-Multiplatform-AppDirs.mingwX64Main should be available" - case seems to be important!